### PR TITLE
[Improvement] Improved mobile menu performance

### DIFF
--- a/web/app/themes/regionhalland/resources/views/partials/navigation/nav-mobile.blade.php
+++ b/web/app/themes/regionhalland/resources/views/partials/navigation/nav-mobile.blade.php
@@ -5,8 +5,8 @@
     <div class="rh-menu-dropdown__header">
         {{-- <img class="rh-menu-dropdown__header-logo" src="{!! env('WP_HOME') !!}/include/img/MH_Greyscale.png"> --}}
         <div class="rh-menu-dropdown__header-logo-container">
-            <a href="{!! env('WP_HOME') !!}">
-                <img class="rh-menu-dropdown__header-logo" src="{!! env('WP_HOME') !!}/include/img/MH_Greyscale.png">
+            <a href="{!! env('WP_HOME') !!}" aria-label="Gå till startsida">
+                <img class="rh-menu-dropdown__header-logo" src="{!! env('WP_HOME') !!}/include/img/MH_Greyscale.png" alt="Region Hallands logotyp">
             </a>
         </div>
         

--- a/web/include/style/development.css
+++ b/web/include/style/development.css
@@ -118,8 +118,8 @@ strong, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
       background-color: #ffffff;
       color: #FA3CB4; }
   
-  /* Mobile dropdown menu - Displays only in SM mode - <= 768px*/
-  .rh-menu-dropdown {
+/* Mobile dropdown menu - Displays only in SM mode - <= 768px*/
+.rh-menu-dropdown {
     /* Positionering */
     position: relative;
     top: 0;
@@ -240,7 +240,6 @@ strong, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
           display: none; } }
     .rh-menu-dropdown--open {
       overflow-y: scroll;
-      overscroll-behavior: contain;
       right: 0;
       bottom: 0;
       left: 0;
@@ -261,9 +260,6 @@ strong, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   
   .rh-display--none {
     display: none; }
-  
-  .rh-display--hide {
-    display: hidden; }
   
   .rh-pl-05 {
     padding-left: 0.3125em; }
@@ -328,5 +324,5 @@ strong, h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   .rh-noscroll {
     overflow: hidden;
     -webkit-overflow-scrolling: auto;
-    height: 100% !important; }
+    height: 100%; }
   


### PR DESCRIPTION
* Använda throttle() funktion för meny-scrolling. Det väntar 150ms innan det gömmer eller tar fram menyn.
* Lägga alt och arial-label för RH logotyp.
* Ta bort overscroll-behavior i CSS klassen .rh-menu-dropdown--open
* Ta bort klassen .rh-display--hide för vi har inte använt.
* Förbättra prestanda för menyn: BodyScrollLock använts bara på iOS för att det låser "content" i bakgrunden när menyn är öppen. Det är onödigt för andra operativsystem (Windows, MacOS, Android).